### PR TITLE
[GITHUB-3] Stop Datadog at the beginning of shutdown process

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -25,3 +25,24 @@
     name: datadog-agent
     state: started
   when: datadog.autostart_agent
+
+- name: Change Datadog Upstart Runlevel - Create Symlinks
+  become: yes
+  file:
+    src: "/etc/init.d/datadog-agent"
+    dest: "{{ item }}"
+    owner: root
+    group: root
+    state: link
+  with_items:
+    - /etc/rc0.d/K05datadog-agent
+    - /etc/rc6.d/K05datadog-agent
+
+- name: Change Datadog Upstart Runlevel - Delete old defunct Symlinks
+  become: yes
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+    - /etc/rc0.d/K20datadog-agent
+    - /etc/rc6.d/K20datadog-agent


### PR DESCRIPTION
This PR aims to remove false positive Datadog alerts when an instance is terminated.

At the end of the service deploy process, after Datadog was started, I have added this task to change the runlevels for shutdown and reboot so that Datadog is stopped before anything else during shutdown or reboot.