### PR TITLE
[GITHUB-6] Add TCP check template

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,37 @@ This role uses one tag: **build**
 
 
 
+## Integrations
+
+The `datadog/templates/conf.d` directory contains the implemented integrations. The majority of them are self explanatory.
+
+#### TCP Check
+
+Sample data structure for TCP Check integration.
+
+```
+roles:
+  - role: sansible.datadog
+    datadog:
+      integrations:
+        tcp_check:
+          - endpoint: "my.domain.com"
+            name: "TCP Check for my.domain.com"
+            port: "443"
+          - endpoint: "your.domain.com"
+            name: "TCP Check for your.domain.com"
+            port: "80"
+            timeout: 2
+            collect_response_time: "false"
+            min_collection_interval: 60
+      tags:
+        - some_app
+        - role:some_app
+```
+
+
+
+
 ## Examples
 
 To install:

--- a/templates/conf.d/tcp_check.yaml.j2
+++ b/templates/conf.d/tcp_check.yaml.j2
@@ -1,0 +1,17 @@
+---
+
+init_config:
+
+instances:
+{% for i in datadog.integrations.tcp_check %}
+
+  - name: {{ i.name }}
+    host: {{ i.endpoint }}
+    port: {{ i.port }}
+    timeout: {{ i.timeout | default(1) }}
+    collect_response_time: {{ i.collect_response_time | default('true') }}
+{% if i.min_collection_interval | default(false) %}
+    min_collection_interval: {{ i.min_collection_interval }}
+{% endif %}
+    skip_event: true
+{% endfor %}


### PR DESCRIPTION
This adds the TCP Check template as documented with http://docs.datadoghq.com/integrations/tcpcheck/. The template supports multiple instance stanzas. The required data structure looks like this;

```
datadog:
  integrations:
    tcp_check:
      endpoint: ["my.domain.com","your.domain.com"]
      name: ["TCP Check for my.domain.com","TCP Check for your.domain.com"]
      port: ["443","80"]
```

The templates renders an error if not all list variables have the same length.