### PR TITLE
[GITHUB-12] Switch to new DD apt key

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -3,7 +3,7 @@
 - name: Ensures Datadog PGP key is known to the server
   become: yes
   apt_key:
-    id: C7A7DA52
+    id: 382E94DE
     keyserver: hkp://keyserver.ubuntu.com:80
     state: present
 

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -6,6 +6,7 @@
   roles:
     - role: sansible.datadog
       datadog:
+        autostart_agent: no
         tags:
           - role:some_app
         integrations:
@@ -26,14 +27,3 @@
               name: "Dummy test"
               port: "80"
           zk: { }
-
-  post_tasks:
-    - name: Datadog should be running
-      become: yes
-      service:
-        name: datadog-agent
-        state: started
-      register: datadog_agent_start_check
-      failed_when: datadog_agent_start_check.changed
-      tags:
-        - assert


### PR DESCRIPTION
DD seem to be using a new key for their apt repo so this switches
us over. Had to stop the tests from starting the agent as it no
longer starts if you don't have a valid license key.