### PR TITLE
[GITHUB-17] Fix Issue with Default Value

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,7 @@ sansible_datadog_collect_instance_metadata: ~
 sansible_datadog_dd_url: http://app.datadoghq.com/
 sansible_datadog_default_tags: []
 sansible_datadog_enabled: yes
-sansible_datadog_hostname: ~
+sansible_datadog_hostname: "{{ ansible_hostname }}"
 sansible_datadog_integrations: {}
 sansible_datadog_socket: /opt/datadog-agent/run/datadog-supervisor.sock
 sansible_datadog_tags: []

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -3,6 +3,13 @@
 - name: Converge
   hosts: all
 
+  pre_tasks:
+    - name: Install GPG
+      become: yes
+      apt:
+        name: gpg
+      when: ansible_distribution_release == 'bionic'
+
   roles:
     - role: datadog
       sansible_datadog_autostart_agent: no

--- a/templates/datadog.conf.j2
+++ b/templates/datadog.conf.j2
@@ -3,6 +3,6 @@ dd_url: {{ sansible_datadog_dd_url }}
 api_key: {{ sansible_datadog_api_key }}
 use_mount: no
 tags: {{ (sansible_datadog_default_tags | list + sansible_datadog_tags | list) | join(',') }}
-hostname: {{ sansible_datadog_hostname | default(ansible_hostname) }}
+hostname: {{ sansible_datadog_hostname }}
 collect_ec2_tags: {{ sansible_datadog_collect_ec2_tags | default('no') }}
 collect_instance_metadata: {{ sansible_datadog_collect_instance_metadata | default('no') }}


### PR DESCRIPTION
In a toplevel variable, `~` is evaluated as defined, whereas in a sublevel variable, it is evaluated as undefined.  The `| default()` filter doesn't work in this case.

Also install GPG on bionic only, as the package is missing in the release version of the docker image.